### PR TITLE
Fix Ctrl+C doesn't work under Windows platform.

### DIFF
--- a/FTC.py
+++ b/FTC.py
@@ -489,6 +489,16 @@ if __name__ == '__main__':
                         help='Use plaintext transfer (default: use ssl)')
     args = parser.parse_args()
 
+    # determine platform, to fix ^c doesn't work on Windows
+    if platform.system() == 'Windows':
+        from win32api import SetConsoleCtrlHandler
+
+        SetConsoleCtrlHandler(lambda ctrl_type:
+                              os.kill(os.getpid(), signal.CTRL_BREAK_EVENT)
+                              if ctrl_type in (signal.CTRL_C_EVENT, signal.CTRL_BREAK_EVENT)
+                              else None
+                              , 1)
+
     # 启动FTC服务
     ftc = FTC(thread_num=args.t, host=args.host, use_ssl=not args.plaintext)
     ftc.probe_server(1)

--- a/FTS.py
+++ b/FTS.py
@@ -274,6 +274,16 @@ if __name__ == '__main__':
         print_color(get_log_msg('已创建文件夹 {}'.format(base_dir)))
 
     fts = FTS(base_dir, not args.plaintext, args.avoid)
+    # determine platform, to fix ^c doesn't work on Windows
+    if platform.system() == 'Windows':
+        from win32api import SetConsoleCtrlHandler
+
+        SetConsoleCtrlHandler(lambda ctrl_type:
+                              os.kill(os.getpid(), signal.CTRL_BREAK_EVENT)
+                              if ctrl_type in (signal.CTRL_C_EVENT, signal.CTRL_BREAK_EVENT)
+                              else None
+                              , 1)
+
     if not packaging:
         fts.main()
     else:

--- a/Utils.py
+++ b/Utils.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import signal
 import struct
 import sys
 import threading

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 tqdm~=4.65.0
 psutil~=5.9.4
+pywin32~=304; sys_platform == 'Windows'


### PR DESCRIPTION
**Problem description:**
Ctrl + C by default terminate program from running ,but doesn't work on Windows.
 **Solution**
Use win32api to explicitly kill the program when running on Windows. 
```python
SetConsoleCtrlHandler(lambda ctrl_type:
                              os.kill(os.getpid(), signal.CTRL_BREAK_EVENT)
                              if ctrl_type in (signal.CTRL_C_EVENT, signal.CTRL_BREAK_EVENT)
                              else None
                              , 1)
```